### PR TITLE
Added Flux Reverse to S8-Style Decks. Press and hold SHIFT+FLUX

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - Browser: Gauges for Key/BPM match (toggle in prefs)
   - Browser: Display 7 or 9 items on screen (toggle in prefs)
   - Deck: Cycle through MixerFX on S5 by pressing SHIFT + FILTER-ON/OFF
+  - Deck: Press SHIFT + FLUX to engage flux reverse
   - Deck: Layout more closely resembles main Traktor layout
   - Deck: All 9 data elements are configurable (set it prefs)
   - Deck: Spectrum colors (toggle in prefs)

--- a/qml/CSI/Common/Deck_S8Style.qml
+++ b/qml/CSI/Common/Deck_S8Style.qml
@@ -4093,7 +4093,8 @@ Module
 
     enabled: (focusedDeckId == 1) && (hasTransport(deckAType))
 
-    Wire { from: "%surface%.flux"; to: "decks.1.transport.flux" }
+    Wire { from: "%surface%.flux"; to: "decks.1.transport.flux" ; enabled: !module.shift}
+    Wire { from: "%surface%.flux"; to: "decks.1.transport.flux_reverse" ; enabled: module.shift}
 
     WiresGroup
     {
@@ -4151,7 +4152,8 @@ Module
 
     enabled: (focusedDeckId == 2) && (hasTransport(deckBType))
 
-    Wire { from: "%surface%.flux";  to: "decks.2.transport.flux" }
+    Wire { from: "%surface%.flux"; to: "decks.2.transport.flux" ; enabled: !module.shift}
+    Wire { from: "%surface%.flux"; to: "decks.2.transport.flux_reverse" ; enabled: module.shift}
 
     WiresGroup
     {
@@ -4209,7 +4211,8 @@ Module
 
     enabled: (focusedDeckId == 3) && (hasTransport(deckCType))
 
-    Wire { from: "%surface%.flux";  to: "decks.3.transport.flux" }
+    Wire { from: "%surface%.flux"; to: "decks.3.transport.flux" ; enabled: !module.shift}
+    Wire { from: "%surface%.flux"; to: "decks.3.transport.flux_reverse" ; enabled: module.shift}
 
     WiresGroup
     {
@@ -4267,7 +4270,8 @@ Module
 
     enabled: (focusedDeckId == 4) && (hasTransport(deckDType))
 
-    Wire { from: "%surface%.flux";  to: "decks.4.transport.flux" }
+    Wire { from: "%surface%.flux"; to: "decks.4.transport.flux" ; enabled: !module.shift}
+    Wire { from: "%surface%.flux"; to: "decks.4.transport.flux_reverse" ; enabled: module.shift}
 
     WiresGroup
     {

--- a/qml/CSI/S5/S5Deck.qml
+++ b/qml/CSI/S5/S5Deck.qml
@@ -3746,7 +3746,8 @@ Module
 
     enabled: (focusedDeckId == 1) && (hasTransport(deckAType))
 
-    Wire { from: "%surface%.flux"; to: "decks.1.transport.flux" }
+    Wire { from: "%surface%.flux"; to: "decks.1.transport.flux" ; enabled: !module.shift}
+    Wire { from: "%surface%.flux"; to: "decks.1.transport.flux_reverse" ; enabled: module.shift}
 
     WiresGroup
     {
@@ -3804,7 +3805,8 @@ Module
 
     enabled: (focusedDeckId == 2) && (hasTransport(deckBType))
 
-    Wire { from: "%surface%.flux";  to: "decks.2.transport.flux" }
+    Wire { from: "%surface%.flux"; to: "decks.2.transport.flux" ; enabled: !module.shift}
+    Wire { from: "%surface%.flux"; to: "decks.2.transport.flux_reverse" ; enabled: module.shift}
 
     WiresGroup
     {
@@ -3862,7 +3864,8 @@ Module
 
     enabled: (focusedDeckId == 3) && (hasTransport(deckCType))
 
-    Wire { from: "%surface%.flux";  to: "decks.3.transport.flux" }
+    Wire { from: "%surface%.flux"; to: "decks.3.transport.flux" ; enabled: !module.shift}
+    Wire { from: "%surface%.flux"; to: "decks.3.transport.flux_reverse" ; enabled: module.shift}
 
     WiresGroup
     {
@@ -3920,7 +3923,8 @@ Module
 
     enabled: (focusedDeckId == 4) && (hasTransport(deckDType))
 
-    Wire { from: "%surface%.flux";  to: "decks.4.transport.flux" }
+    Wire { from: "%surface%.flux"; to: "decks.4.transport.flux" ; enabled: !module.shift}
+    Wire { from: "%surface%.flux"; to: "decks.4.transport.flux_reverse" ; enabled: module.shift}
 
     WiresGroup
     {


### PR DESCRIPTION
The new Traktor S4 & S2 MK3 have a reverse button. Holding this down will temporarily activate Flux mode and begin to play the track in reverse. There wasn't any way of controlling this on the S8/S5/D2 so I decided to add it. Simply press SHIFT + FLUX on the corresponding deck in order to activate Flux Reverse.