### PR TITLE
Dynamic font sizing in deck header fields

### DIFF
--- a/qml/Screens/S8/Views/Deck/DeckHeader.qml
+++ b/qml/Screens/S8/Views/Deck/DeckHeader.qml
@@ -217,6 +217,8 @@ Item {
     color:      textState == 17 || textState == 18 || textState == 31 ? 
       parent.colorForKey(utils.returnKeyIndex(deckKeyDisplay.value)) : textColors[deck_Id]
     elide:     Text.ElideRight
+    fontSizeMode:       Text.HorizontalFit
+    minimumPixelSize:   fonts.smallFontSize
     font.pixelSize:     fonts.largeFontSize // set in state
     anchors.top:        parent.top
     anchors.left:       cover_small.right
@@ -237,7 +239,9 @@ Item {
     textState:  topCenterState
     color:      textState == 17 || textState == 18 || textState == 31 ? 
       parent.colorForKey(utils.returnKeyIndex(deckKeyDisplay.value)) : textColors[deck_Id]
-    font.pixelSize: fonts.largeFontSize
+    fontSizeMode:       Text.HorizontalFit
+    minimumPixelSize:   fonts.smallFontSize
+    font.pixelSize:     fonts.largeFontSize
     anchors.top:          parent.top
     anchors.right:        top_right_text.left
     horizontalAlignment: Text.AlignRight
@@ -257,7 +261,9 @@ Item {
     textState:  topRightState
     color:      textState == 17 || textState == 18 || textState == 31 ? 
       parent.colorForKey(utils.returnKeyIndex(deckKeyDisplay.value)) : textColors[deck_Id]
-    font.pixelSize: fonts.largeFontSize
+    fontSizeMode:       Text.HorizontalFit
+    minimumPixelSize:   fonts.smallFontSize
+    font.pixelSize:     fonts.largeFontSize
     anchors.top:          parent.top
     anchors.right:        parent.right
     anchors.rightMargin:  rightFieldMargin
@@ -278,6 +284,8 @@ Item {
     color:      textState == 17 || textState == 18 || textState == 31 ? 
       parent.colorForKey(utils.returnKeyIndex(deckKeyDisplay.value)) : darkerTextColors[deck_Id]
     elide:      Text.ElideRight
+    fontSizeMode:       Text.HorizontalFit
+    minimumPixelSize:   fonts.miniFontSize
     font.pixelSize:     fonts.middleFontSize
     anchors.top:        top_left_text.bottom
     anchors.left:       cover_small.right
@@ -300,7 +308,9 @@ Item {
       parent.colorForKey(utils.returnKeyIndex(deckKeyDisplay.value)) : darkerTextColors[deck_Id]
     elide:      Text.ElideRight
     opacity:    _intSetInState        // set by 'state'
-    font.pixelSize: fonts.middleFontSize
+    fontSizeMode:       Text.HorizontalFit
+    minimumPixelSize:   fonts.miniFontSize
+    font.pixelSize:     fonts.middleFontSize
     anchors.top:          top_middle_text.bottom
     anchors.right:        middle_right_text.left
     horizontalAlignment: Text.AlignRight
@@ -323,7 +333,9 @@ Item {
     color:      textState == 17 || textState == 18 || textState == 31 ? 
       parent.colorForKey(utils.returnKeyIndex(deckKeyDisplay.value)) : darkerTextColors[deck_Id]
     opacity:    _intSetInState          // set by 'state'
-    font.pixelSize: fonts.middleFontSize
+    fontSizeMode:       Text.HorizontalFit
+    minimumPixelSize:   fonts.miniFontSize
+    font.pixelSize:     fonts.middleFontSize
     horizontalAlignment: Text.AlignRight
     verticalAlignment: Text.AlignVCenter
     onTextChanged: {updateHeader()}
@@ -343,6 +355,8 @@ Item {
       parent.colorForKey(utils.returnKeyIndex(deckKeyDisplay.value)) : darkerTextColors[deck_Id]
     elide:      Text.ElideRight
     opacity:    _intSetInState        // set by 'state'
+    fontSizeMode:       Text.HorizontalFit
+    minimumPixelSize:   fonts.miniFontSize
     font.pixelSize:     fonts.middleFontSize
     anchors.top:        middle_left_text.bottom
     anchors.left:       cover_small.right
@@ -367,7 +381,9 @@ Item {
     color:      textState == 17 || textState == 18 || textState == 31 ? 
       parent.colorForKey(utils.returnKeyIndex(deckKeyDisplay.value)) : darkerTextColors[deck_Id]
     opacity: _intSetInState          // set by 'state'
-    font.pixelSize: fonts.middleFontSize
+    fontSizeMode:       Text.HorizontalFit
+    minimumPixelSize:   fonts.miniFontSize
+    font.pixelSize:     fonts.middleFontSize
     horizontalAlignment: Text.AlignRight
     verticalAlignment: Text.AlignVCenter
     Behavior on opacity             { NumberAnimation { duration: speed } }
@@ -389,7 +405,9 @@ Item {
     color:      textState == 17 || textState == 18 || textState == 31 ? 
       parent.colorForKey(utils.returnKeyIndex(deckKeyDisplay.value)) : darkerTextColors[deck_Id]
     opacity:    _intSetInState          // set by 'state'
-    font.pixelSize: fonts.middleFontSize
+    fontSizeMode:       Text.HorizontalFit
+    minimumPixelSize:   fonts.miniFontSize
+    font.pixelSize:     fonts.middleFontSize
     horizontalAlignment: Text.AlignRight
     verticalAlignment: Text.AlignVCenter
     Behavior on opacity             { NumberAnimation { duration: speed } }


### PR DESCRIPTION
Hi Kokernutz,

i really enjoy your QML mods for the S8, and I want to share with you some of the tweaks and further enhancements I made to them. Please feel free to pick and merge if you like them 👍 

The first one is a simple tweak that enables QTs dynamic font sizing in the deck headers. This allows longer Titles, Artist Names or Comments to be displayed on the screens, while still defaulting to usual size for shorter ones:
![img_0265](https://user-images.githubusercontent.com/1044267/50608377-cd2e6d80-0ecc-11e9-918a-416ccfed17d0.jpg)
![img_0268](https://user-images.githubusercontent.com/1044267/50608389-d4ee1200-0ecc-11e9-90b6-a4e2b8a27bae.jpg)
Another example with a long Artist name:
![img_0267](https://user-images.githubusercontent.com/1044267/50608412-e6cfb500-0ecc-11e9-9d25-a4a3d2ffd1b8.jpg)

Cheers
Nils