### PR TITLE
Updated the property path for track key to Traktor 3.2

### DIFF
--- a/qml/Screens/S4MK3/ViewModels/DeckInfo.qml
+++ b/qml/Screens/S4MK3/ViewModels/DeckInfo.qml
@@ -50,7 +50,7 @@ Item
   AppProperty { id: propDeckType;               path: "app.traktor.decks." + deckId + ".type" }
   AppProperty { id: propTitle;                  path: "app.traktor.decks." + deckId + ".content.title" }
   AppProperty { id: propArtist;                 path: "app.traktor.decks." + deckId + ".content.artist" }
-  AppProperty { id: propKeyForDisplay;          path: "app.traktor.decks." + deckId + ".track.key.key_for_display" }
+  AppProperty { id: propKeyForDisplay;          path: "app.traktor.decks." + deckId + ".track.key.resulting.precise" }
   AppProperty { id: propFinalKeyId;             path: "app.traktor.decks." + deckId + ".track.key.final_id" }
   AppProperty { id: propKeyAdjust;              path: "app.traktor.decks." + deckId + ".track.key.adjust" }
   AppProperty { id: propKeyLockOn;              path: "app.traktor.decks." + deckId + ".track.key.lock_enabled" }

--- a/qml/Screens/S8/Views/Browser/ListDelegate.qml
+++ b/qml/Screens/S8/Views/Browser/ListDelegate.qml
@@ -31,7 +31,7 @@ Item {
   property int            browserFontSize:        prefs.displayMoreItems ? fonts.scale(15) : fonts.scale(16)
 
   AppProperty { id: masterClockBpm;   path: "app.traktor.masterclock.tempo"; onValueChanged: { updateMatchInfo(); } }
-  AppProperty { id: masterKeyDisplay; path: "app.traktor.decks." + (masterDeckId.value + 1) + ".track.key.key_for_display" ; onValueChanged: { updateMatchInfo(); }}
+  AppProperty { id: masterKeyDisplay; path: "app.traktor.decks." + (masterDeckId.value + 1) + ".track.key.resulting.precise" ; onValueChanged: { updateMatchInfo(); }}
   AppProperty { id: masterDeckId;     path: "app.traktor.masterclock.source_id"; onValueChanged: { updateMatchInfo(); } }
 
   height: prefs.displayMoreItems ? 25 : 32

--- a/qml/Screens/S8/Views/Deck/DeckHeader.qml
+++ b/qml/Screens/S8/Views/Deck/DeckHeader.qml
@@ -90,7 +90,7 @@ Item {
   //  DECK PROPERTIES
   //--------------------------------------------------------------------------------------------------------------------
 
-  AppProperty { id: deckKeyDisplay;     path: "app.traktor.decks." + (deckId+1) + ".track.key.key_for_display"; onValueChanged: { updateKeyColor() } }
+  AppProperty { id: deckKeyDisplay;     path: "app.traktor.decks." + (deckId+1) + ".track.key.resulting.precise"; onValueChanged: { updateKeyColor() } }
   AppProperty { id: propMusicalKey;     path: "app.traktor.decks." + (deckId+1) + ".content.musical_key" }
   AppProperty { id: propSyncMasterDeck; path: "app.traktor.masterclock.source_id" }
 

--- a/qml/Screens/S8/Views/Deck/DeckHeaderText.qml
+++ b/qml/Screens/S8/Views/Deck/DeckHeaderText.qml
@@ -185,7 +185,7 @@ Text {
     State { 
       name: "key"; 
       PropertyChanges { target: header_text; font.family: fontForNumber;
-                        text:   (!isLoaded)?"":propMusicalKey.value.toString(); }
+                        text:   (!isLoaded)?"":deckKeyDisplay.value.toString(); }
     },
     State { 
       name: "keyText"; 

--- a/qml/Screens/S8/Views/Overlays/CenterOverlays/Keylock.qml
+++ b/qml/Screens/S8/Views/Overlays/CenterOverlays/Keylock.qml
@@ -18,7 +18,7 @@ CenterOverlay {
 
   AppProperty { id: keyValue;   path: "app.traktor.decks." + (deckId+1) + ".track.key.adjust" }
   AppProperty { id: keyEnable;  path: "app.traktor.decks." + (deckId+1) + ".track.key.lock_enabled" }
-  AppProperty { id: keyDisplay; path: "app.traktor.decks." + (deckId+1) + ".track.key.key_for_display" }
+  AppProperty { id: keyDisplay; path: "app.traktor.decks." + (deckId+1) + ".track.key.resulting.precise" }
 
   property real key:    keyValue.value * 12
   property int  offset: (key.toFixed(2) - key.toFixed(0)) * 100.0


### PR DESCRIPTION
Fixes #31 

Also changes the displayed value for deck info option 17 ("key") to the current key, taking pitch and key bending into account.

Tested on S5 - Traktor 3.2.0