### PR TITLE
Mixer FX selector [S8 and S5]

### DIFF
--- a/CSI/Common/Deck_S8Style.qml
+++ b/CSI/Common/Deck_S8Style.qml
@@ -2,6 +2,7 @@ import CSI 1.0
 import QtQuick 2.0
 
 import "../../Defines"
+import "../../Screens/Defines"
 
 Module
 {
@@ -1403,8 +1404,8 @@ Module
           enabled: focusedDeckId == 1
 
           Wire { from: "%surface%.back";   to: "decks.1.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.1.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.1.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.1.tempo.fine" : "decks.1.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.1.tempo.coarse" : "decks.1.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck B
@@ -1413,8 +1414,8 @@ Module
           enabled: focusedDeckId == 2
 
           Wire { from: "%surface%.back";   to: "decks.2.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.2.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.2.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.2.tempo.fine" : "decks.2.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.2.tempo.coarse" : "decks.2.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck C
@@ -1423,8 +1424,8 @@ Module
           enabled: focusedDeckId == 3
 
           Wire { from: "%surface%.back";   to: "decks.3.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.3.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.3.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.3.tempo.fine" : "decks.3.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.3.tempo.coarse" : "decks.3.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck D
@@ -1433,8 +1434,8 @@ Module
           enabled: focusedDeckId == 4
 
           Wire { from: "%surface%.back";   to: "decks.4.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.4.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.4.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.4.tempo.fine" : "decks.4.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.4.tempo.coarse" : "decks.4.tempo.fine"; enabled:  module.shift }
         }
       }
 
@@ -4593,6 +4594,10 @@ Module
         Wire { from: "%surface%.knobs.4";       to: RelativePropertyAdapter { path: "app.traktor.midi.knobs.8" } }
       }
     }
+  }
+
+  Prefs{
+    id:prefs
   }
 
   /* #ifdef DEVELOPMENT_MODE

--- a/CSI/S5/Channel.qml
+++ b/CSI/S5/Channel.qml
@@ -1,4 +1,6 @@
 import CSI 1.0
+import QtQuick 2.0
+import "../../Screens/Defines"
 
 Module
 {
@@ -30,19 +32,60 @@ Module
   // fx Assign
 
   AppProperty { id: fxMode; path: "app.traktor.fx.4fx_units" }
+  AppProperty { id: mixerFXOn; path: app_prefix + "fx.on" }
+  AppProperty { id: mixerFX; path: app_prefix + "fx.select" }
 
   WiresGroup
   {
-    enabled: !channel.shift || (fxMode.value == FxMode.TwoFxUnits)
+    enabled: (!channel.shift || (fxMode.value == FxMode.TwoFxUnits)) && !prefs.mixerFXSelector && !prefs.prioritizeFXSelection
     Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
     Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
   }
 
   WiresGroup
   {
-    enabled: channel.shift && (fxMode.value == FxMode.FourFxUnits)
+    enabled: (!channel.shift) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (!channel.shift) && prefs.mixerFXSelector && prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 4) % 5; } } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 1) % 5; } } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (fxMode.value == FxMode.FourFxUnits)) && !prefs.mixerFXSelector && !prefs.prioritizeFXSelection
     Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.3"; } }
     Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.4"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (!mixerFXOn.value && fxMode.value == FxMode.FourFxUnits)) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.3"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.4"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (mixerFXOn.value || fxMode.value == FxMode.TwoFxUnits)) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 4) % 5; } } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 1) % 5; } } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift) && prefs.mixerFXSelector && prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
+  }
+
+  Prefs{
+    id:prefs
   }
 
 }

--- a/CSI/S5/Mixer.qml
+++ b/CSI/S5/Mixer.qml
@@ -1,4 +1,6 @@
 import CSI 1.0
+import QtQuick 2.0
+import "../../Screens/Defines"
 
 Module
 {
@@ -8,8 +10,8 @@ Module
 
   // Master Clock
 	MasterClock { name: "MasterTempo" }
-  Wire { from: "%surface%.mixer.tempo"; to: "MasterTempo.coarse"; enabled:  shift }
-  Wire { from: "%surface%.mixer.tempo"; to: "MasterTempo.fine";   enabled: !shift }
+  Wire { from: "%surface%.mixer.tempo"; to: (prefs.fineMasterTempoAdjust) ? "MasterTempo.coarse" : "MasterTempo.fine"; enabled:  shift }
+  Wire { from: "%surface%.mixer.tempo"; to: (prefs.fineMasterTempoAdjust) ? "MasterTempo.fine" : "MasterTempo.coarse";   enabled: !shift }
 
 
   // Channels
@@ -55,4 +57,8 @@ Module
   // Master Clip
   Wire { from: "%surface%.mixer.clip.left";   to: DirectPropertyAdapter { path: "app.traktor.mixer.master.level.clip.left"  } }
   Wire { from: "%surface%.mixer.clip.right";  to: DirectPropertyAdapter { path: "app.traktor.mixer.master.level.clip.right" } }
+
+  Prefs{
+    id:prefs
+  }
 }

--- a/CSI/S5/S5Deck.qml
+++ b/CSI/S5/S5Deck.qml
@@ -3,6 +3,7 @@ import QtQuick 2.0
 
 import "../../Defines"
 import "../Common"
+import "../../Screens/Defines"
 
 Module
 {
@@ -1568,8 +1569,8 @@ Module
           enabled: focusedDeckId == 1
 
           Wire { from: "%surface%.back";   to: "decks.1.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.1.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.1.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.1.tempo.fine" : "decks.1.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.1.tempo.coarse" : "decks.1.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck B
@@ -1578,8 +1579,8 @@ Module
           enabled: focusedDeckId == 2
 
           Wire { from: "%surface%.back";   to: "decks.2.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.2.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.2.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.2.tempo.fine" : "decks.2.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.2.tempo.coarse" : "decks.2.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck C
@@ -1588,8 +1589,8 @@ Module
           enabled: focusedDeckId == 3
 
           Wire { from: "%surface%.back";   to: "decks.3.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.3.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.3.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.3.tempo.fine" : "decks.3.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.3.tempo.coarse" : "decks.3.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck D
@@ -1598,8 +1599,8 @@ Module
           enabled: focusedDeckId == 4
 
           Wire { from: "%surface%.back";   to: "decks.4.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.4.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.4.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.4.tempo.fine" : "decks.4.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.4.tempo.coarse" : "decks.4.tempo.fine"; enabled:  module.shift }
         }
       }
 
@@ -4120,6 +4121,10 @@ Module
       Wire { from: "softtakeover_knobs3.module.output"; to: "fx_units.2.knob2"   }
       Wire { from: "softtakeover_knobs4.module.output"; to: "fx_units.2.knob3"   }
     }
+  }
+
+  Prefs{
+    id:prefs
   }
 
   /* #ifdef DEVELOPMENT_MODE

--- a/CSI/S8/Channel.qml
+++ b/CSI/S8/Channel.qml
@@ -35,19 +35,60 @@ Module
   // fx Assign
 
   AppProperty { id: fxMode; path: "app.traktor.fx.4fx_units" }
+  AppProperty { id: mixerFXOn; path: app_prefix + "fx.on" }
+  AppProperty { id: mixerFX; path: app_prefix + "fx.select" }
 
   WiresGroup
   {
-    enabled: !channel.shift || (fxMode.value == FxMode.TwoFxUnits)
+    enabled: (!channel.shift || (fxMode.value == FxMode.TwoFxUnits)) && !prefs.mixerFXSelector && !prefs.prioritizeFXSelection
     Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
     Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
   }
 
   WiresGroup
   {
-    enabled: channel.shift && (fxMode.value == FxMode.FourFxUnits)
+    enabled: (!channel.shift) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (!channel.shift) && prefs.mixerFXSelector && prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 4) % 5; } } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 1) % 5; } } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (fxMode.value == FxMode.FourFxUnits)) && !prefs.mixerFXSelector && !prefs.prioritizeFXSelection
     Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.3"; } }
     Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.4"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (!mixerFXOn.value && fxMode.value == FxMode.FourFxUnits)) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.3"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.4"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (mixerFXOn.value || fxMode.value == FxMode.TwoFxUnits)) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 4) % 5; } } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 1) % 5; } } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift) && prefs.mixerFXSelector && prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
+  }
+
+  Prefs{
+    id:prefs
   }
 
 }

--- a/CSI/S8/Channel.qml
+++ b/CSI/S8/Channel.qml
@@ -1,4 +1,6 @@
 import CSI 1.0
+import QtQuick 2.0
+import "../../Screens/Defines"
 
 Module
 {

--- a/CSI/S8/Mixer.qml
+++ b/CSI/S8/Mixer.qml
@@ -1,4 +1,6 @@
 import CSI 1.0
+import QtQuick 2.0
+import "../../Screens/Defines"
 
 Module
 {
@@ -8,8 +10,8 @@ Module
 
   // Master Clock
 	MasterClock { name: "MasterTempo" }
-  Wire { from: "%surface%.mixer.tempo"; to: "MasterTempo.coarse"; enabled:  shift }
-  Wire { from: "%surface%.mixer.tempo"; to: "MasterTempo.fine";   enabled: !shift }
+  Wire { from: "%surface%.mixer.tempo"; to: (prefs.fineMasterTempoAdjust) ? "MasterTempo.coarse" : "MasterTempo.fine"; enabled:  shift }
+  Wire { from: "%surface%.mixer.tempo"; to: (prefs.fineMasterTempoAdjust) ? "MasterTempo.fine" : "MasterTempo.coarse";   enabled: !shift }
 
   // Channels
   Channel
@@ -51,4 +53,9 @@ Module
   // Snap / Quant
   Wire { from: "%surface%.mixer.snap";  to: TogglePropertyAdapter { path: "app.traktor.snap";  } }
   Wire { from: "%surface%.mixer.quant"; to: TogglePropertyAdapter { path: "app.traktor.quant"; } }
+
+  Prefs{
+    id:prefs
+  }
+  
 }

--- a/Screens/Defines/Prefs.qml
+++ b/Screens/Defines/Prefs.qml
@@ -5,6 +5,8 @@ QtObject {
 	// controller preferences
 	readonly property bool fineMasterTempoAdjust:    true
 	readonly property bool fineDeckTempoAdjust:        true
+	readonly property bool mixerFXSelector:            true
+	readonly property bool prioritizeFXSelection:    true
 
 	// global preferences
 	readonly property bool camelotKey: 				true

--- a/Screens/Defines/Prefs.qml
+++ b/Screens/Defines/Prefs.qml
@@ -2,6 +2,10 @@ import QtQuick 2.0
 
 QtObject {
 
+	// controller preferences
+	readonly property bool fineMasterTempoAdjust:    true
+	readonly property bool fineDeckTempoAdjust:        true
+
 	// global preferences
 	readonly property bool camelotKey: 				true
 	readonly property int  phraseLength:            4

--- a/Screens/Defines/Prefs.qml
+++ b/Screens/Defines/Prefs.qml
@@ -5,8 +5,8 @@ QtObject {
 	// controller preferences
 	readonly property bool fineMasterTempoAdjust:    true
 	readonly property bool fineDeckTempoAdjust:        true
-	readonly property bool mixerFXSelector:            true
-	readonly property bool prioritizeFXSelection:    true
+	readonly property bool mixerFXSelector:			false
+	readonly property bool prioritizeFXSelection:	true
 
 	// global preferences
 	readonly property bool camelotKey: 				true

--- a/Screens/S8/Views/Deck/TrackDeck.qml
+++ b/Screens/S8/Views/Deck/TrackDeck.qml
@@ -16,8 +16,8 @@ Item {
 
   readonly property int waveformHeight: (deckSizeState == "small") ? 0 : ( parent ? ( (deckSizeState == "medium") ? (parent.height-55) : (parent.height-70) ) : 0 )
 
-  readonly property int largeDeckBottomMargin: (waveformContainer.isStemStyleDeck) ? 6 : 6  
-  readonly property int smallDeckBottomMargin: (deckId > 1) ? 9 : 6
+  readonly property int largeDeckBottomMargin: (waveformContainer.isStemStyleDeck) ? 1 : 1  
+  readonly property int smallDeckBottomMargin: (deckId > 1) ? 1 : 1
 
   property bool showLoopSize: false
   property int  zoomLevel:    1

--- a/Screens/S8/Views/Waveform/WaveformContainer.qml
+++ b/Screens/S8/Views/Waveform/WaveformContainer.qml
@@ -211,7 +211,7 @@ Item {
     deckId:          view.deckId
     anchors.fill:    stemWaveform
     visible:         stemWaveform.visible
-    indicatorHeight: (slicer.enabled && !beatgrid.editEnabled ) ? [34 , 33 , 33 , 33] : [36 , 36 , 36 , 36]
+    indicatorHeight: (slicer.enabled && !beatgrid.editEnabled ) ? [26 , 26 , 26 , 26] : [30 , 30 , 30 , 30]
   }
 
   //--------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Gives S8 and S5 users the option to use the FX assignment buttons (the little arrows at the top of each channel) to change the Mixer FX. These settings can be changed in the prefs.qml file.

If **mixerFXSelector** is set to **false** then this functionality will be disabled and the FX assignment buttons will function as normal, if this is set to **true** then pressing the Arrow buttons will assign FX units 1 and 2 to the respective channel if **prioritizeFXSelection** is set to **false**, pressing SHIFT+Arrows change the MixerFX but only if the filter is on, otherwise it will assign FX units 3 and 4. But if **prioritizeFXSelection** is set to **true** then the arrow buttons will change the Mixer FX and pressing SHIFT + Arrows will assign FX units 1 and 2, this removes the ability to reassign FX units 3 and 4.