### PR TITLE
Stem Color Bars Fix

### DIFF
--- a/Screens/S8/Views/Deck/TrackDeck.qml
+++ b/Screens/S8/Views/Deck/TrackDeck.qml
@@ -16,8 +16,8 @@ Item {
 
   readonly property int waveformHeight: (deckSizeState == "small") ? 0 : ( parent ? ( (deckSizeState == "medium") ? (parent.height-55) : (parent.height-70) ) : 0 )
 
-  readonly property int largeDeckBottomMargin: (waveformContainer.isStemStyleDeck) ? 6 : 6  
-  readonly property int smallDeckBottomMargin: (deckId > 1) ? 9 : 6
+  readonly property int largeDeckBottomMargin: (waveformContainer.isStemStyleDeck) ? 1 : 1  
+  readonly property int smallDeckBottomMargin: (deckId > 1) ? 1 : 1
 
   property bool showLoopSize: false
   property int  zoomLevel:    1

--- a/Screens/S8/Views/Waveform/WaveformContainer.qml
+++ b/Screens/S8/Views/Waveform/WaveformContainer.qml
@@ -5,6 +5,7 @@ import Traktor.Gui 1.0 as T
 
 import '../../../../Defines'
 import '../Widgets' as Widgets
+import '../../../Defines'
 
 
 Item {
@@ -211,7 +212,7 @@ Item {
     deckId:          view.deckId
     anchors.fill:    stemWaveform
     visible:         stemWaveform.visible
-    indicatorHeight: (slicer.enabled && !beatgrid.editEnabled ) ? [34 , 33 , 33 , 33] : [36 , 36 , 36 , 36]
+    indicatorHeight: (slicer.enabled && !beatgrid.editEnabled ) ? [34 , 33 , 33 , 33] : (prefs.displayHotCueBar) ? [26, 26, 26, 26] : [30 , 30 , 30 , 30]
   }
 
   //--------------------------------------------------------------------------------------------------------------------
@@ -267,5 +268,10 @@ Item {
       }
     }
   ]
+
+  Prefs
+  {
+    id:prefs
+  }
 
 }


### PR DESCRIPTION
Fixed the Stem color bars being oversized and therefore misaligned with the actual tracks, also fixed the gap between the waveform preview and the footer as to make it look cleaner and be more space efficient.