### PR TITLE
Coarse BPM Adjust Setting

### DIFF
--- a/CSI/Common/Deck_S8Style.qml
+++ b/CSI/Common/Deck_S8Style.qml
@@ -2,6 +2,7 @@ import CSI 1.0
 import QtQuick 2.0
 
 import "../../Defines"
+import "../../Screens/Defines"
 
 Module
 {
@@ -1403,8 +1404,8 @@ Module
           enabled: focusedDeckId == 1
 
           Wire { from: "%surface%.back";   to: "decks.1.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.1.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.1.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.1.tempo.fine" : "decks.1.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.1.tempo.coarse" : "decks.1.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck B
@@ -1413,8 +1414,8 @@ Module
           enabled: focusedDeckId == 2
 
           Wire { from: "%surface%.back";   to: "decks.2.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.2.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.2.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.2.tempo.fine" : "decks.2.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.2.tempo.coarse" : "decks.2.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck C
@@ -1423,8 +1424,8 @@ Module
           enabled: focusedDeckId == 3
 
           Wire { from: "%surface%.back";   to: "decks.3.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.3.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.3.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.3.tempo.fine" : "decks.3.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.3.tempo.coarse" : "decks.3.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck D
@@ -1433,8 +1434,8 @@ Module
           enabled: focusedDeckId == 4
 
           Wire { from: "%surface%.back";   to: "decks.4.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.4.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.4.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.4.tempo.fine" : "decks.4.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.4.tempo.coarse" : "decks.4.tempo.fine"; enabled:  module.shift }
         }
       }
 
@@ -4593,6 +4594,11 @@ Module
         Wire { from: "%surface%.knobs.4";       to: RelativePropertyAdapter { path: "app.traktor.midi.knobs.8" } }
       }
     }
+  }
+
+  Prefs
+  {
+    id:prefs
   }
 
   /* #ifdef DEVELOPMENT_MODE

--- a/CSI/S5/Mixer.qml
+++ b/CSI/S5/Mixer.qml
@@ -1,4 +1,6 @@
 import CSI 1.0
+import QtQuick 2.0
+import "../../Screens/Defines"
 
 Module
 {
@@ -8,8 +10,8 @@ Module
 
   // Master Clock
 	MasterClock { name: "MasterTempo" }
-  Wire { from: "%surface%.mixer.tempo"; to: "MasterTempo.coarse"; enabled:  shift }
-  Wire { from: "%surface%.mixer.tempo"; to: "MasterTempo.fine";   enabled: !shift }
+  Wire { from: "%surface%.mixer.tempo"; to: (prefs.fineMasterTempoAdjust) ? "MasterTempo.coarse" : "MasterTempo.fine"; enabled:  shift }
+  Wire { from: "%surface%.mixer.tempo"; to: (prefs.fineMasterTempoAdjust) ? "MasterTempo.fine" : "MasterTempo.coarse";   enabled: !shift }
 
 
   // Channels
@@ -55,4 +57,9 @@ Module
   // Master Clip
   Wire { from: "%surface%.mixer.clip.left";   to: DirectPropertyAdapter { path: "app.traktor.mixer.master.level.clip.left"  } }
   Wire { from: "%surface%.mixer.clip.right";  to: DirectPropertyAdapter { path: "app.traktor.mixer.master.level.clip.right" } }
+
+  Prefs
+  {
+    id:prefs
+  }
 }

--- a/CSI/S5/S5Deck.qml
+++ b/CSI/S5/S5Deck.qml
@@ -3,6 +3,7 @@ import QtQuick 2.0
 
 import "../../Defines"
 import "../Common"
+import "../../Screens/Defines"
 
 Module
 {
@@ -1568,8 +1569,8 @@ Module
           enabled: focusedDeckId == 1
 
           Wire { from: "%surface%.back";   to: "decks.1.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.1.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.1.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.1.tempo.fine" : "decks.1.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.1.tempo.coarse" : "decks.1.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck B
@@ -1578,8 +1579,8 @@ Module
           enabled: focusedDeckId == 2
 
           Wire { from: "%surface%.back";   to: "decks.2.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.2.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.2.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.2.tempo.fine" : "decks.2.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.2.tempo.coarse" : "decks.2.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck C
@@ -1588,8 +1589,8 @@ Module
           enabled: focusedDeckId == 3
 
           Wire { from: "%surface%.back";   to: "decks.3.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.3.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.3.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.3.tempo.fine" : "decks.3.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.3.tempo.coarse" : "decks.3.tempo.fine"; enabled:  module.shift }
         }
 
         // Deck D
@@ -1598,8 +1599,8 @@ Module
           enabled: focusedDeckId == 4
 
           Wire { from: "%surface%.back";   to: "decks.4.tempo.reset" }
-          Wire { from: "%surface%.browse"; to: "decks.4.tempo.fine";   enabled: !module.shift }
-          Wire { from: "%surface%.browse"; to: "decks.4.tempo.coarse"; enabled:  module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.4.tempo.fine" : "decks.4.tempo.coarse";   enabled: !module.shift }
+          Wire { from: "%surface%.browse"; to: (prefs.fineDeckTempoAdjust) ? "decks.4.tempo.coarse" : "decks.4.tempo.fine"; enabled:  module.shift }
         }
       }
 
@@ -4120,6 +4121,11 @@ Module
       Wire { from: "softtakeover_knobs3.module.output"; to: "fx_units.2.knob2"   }
       Wire { from: "softtakeover_knobs4.module.output"; to: "fx_units.2.knob3"   }
     }
+  }
+
+  Prefs
+  {
+    id:prefs
   }
 
   /* #ifdef DEVELOPMENT_MODE

--- a/CSI/S8/Mixer.qml
+++ b/CSI/S8/Mixer.qml
@@ -1,4 +1,6 @@
 import CSI 1.0
+import QtQuick 2.0
+import "../../Screens/Defines"
 
 Module
 {
@@ -8,8 +10,8 @@ Module
 
   // Master Clock
 	MasterClock { name: "MasterTempo" }
-  Wire { from: "%surface%.mixer.tempo"; to: "MasterTempo.coarse"; enabled:  shift }
-  Wire { from: "%surface%.mixer.tempo"; to: "MasterTempo.fine";   enabled: !shift }
+  Wire { from: "%surface%.mixer.tempo"; to: (prefs.fineMasterTempoAdjust) ? "MasterTempo.coarse" : "MasterTempo.fine"; enabled:  shift }
+  Wire { from: "%surface%.mixer.tempo"; to: (prefs.fineMasterTempoAdjust) ? "MasterTempo.fine" : "MasterTempo.coarse";   enabled: !shift }
 
   // Channels
   Channel
@@ -51,4 +53,9 @@ Module
   // Snap / Quant
   Wire { from: "%surface%.mixer.snap";  to: TogglePropertyAdapter { path: "app.traktor.snap";  } }
   Wire { from: "%surface%.mixer.quant"; to: TogglePropertyAdapter { path: "app.traktor.quant"; } }
+
+  Prefs
+  {
+    id:prefs
+  }
 }

--- a/Screens/Defines/Prefs.qml
+++ b/Screens/Defines/Prefs.qml
@@ -2,6 +2,10 @@ import QtQuick 2.0
 
 QtObject {
 
+	// controller preferences
+	readonly property bool fineMasterTempoAdjust:	true
+	readonly property bool fineDeckTempoAdjust:		true
+
 	// global preferences
 	readonly property bool camelotKey: 				true
 	readonly property int  phraseLength:            4


### PR DESCRIPTION
Added the option to have Coarse tempo adjust as default for decks and master clock. For D2, S5 and S8.
By default turning the Tempo encoder adjusts 1/100 of a BPM per click and 1 BPM if the shift key is held down, this option simply inverts the shift functionality. Users can change this in the prefs.qml file.
I've seen other screen mods have this feature and I think it's really missing here.