### PR TITLE
Mixer FX Selector [S8 and S5]

### DIFF
--- a/CSI/S5/Channel.qml
+++ b/CSI/S5/Channel.qml
@@ -1,4 +1,6 @@
 import CSI 1.0
+import QtQuick 2.0
+import "../../Screens/Defines"
 
 Module
 {
@@ -30,19 +32,60 @@ Module
   // fx Assign
 
   AppProperty { id: fxMode; path: "app.traktor.fx.4fx_units" }
+  AppProperty { id: mixerFXOn; path: app_prefix + "fx.on" }
+  AppProperty { id: mixerFX; path: app_prefix + "fx.select" }
 
   WiresGroup
   {
-    enabled: !channel.shift || (fxMode.value == FxMode.TwoFxUnits)
+    enabled: (!channel.shift || (fxMode.value == FxMode.TwoFxUnits)) && !prefs.mixerFXSelector && !prefs.prioritizeFXSelection
     Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
     Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
   }
 
   WiresGroup
   {
-    enabled: channel.shift && (fxMode.value == FxMode.FourFxUnits)
+    enabled: (!channel.shift) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (!channel.shift) && prefs.mixerFXSelector && prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 4) % 5; } } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 1) % 5; } } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (fxMode.value == FxMode.FourFxUnits)) && !prefs.mixerFXSelector && !prefs.prioritizeFXSelection
     Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.3"; } }
     Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.4"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (!mixerFXOn.value && fxMode.value == FxMode.FourFxUnits)) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.3"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.4"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (mixerFXOn.value || fxMode.value == FxMode.TwoFxUnits)) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 4) % 5; } } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 1) % 5; } } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift) && prefs.mixerFXSelector && prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
+  }
+
+  Prefs{
+    id:prefs
   }
 
 }

--- a/CSI/S8/Channel.qml
+++ b/CSI/S8/Channel.qml
@@ -1,4 +1,6 @@
 import CSI 1.0
+import QtQuick 2.0
+import "../../Screens/Defines"
 
 Module
 {
@@ -35,19 +37,60 @@ Module
   // fx Assign
 
   AppProperty { id: fxMode; path: "app.traktor.fx.4fx_units" }
+  AppProperty { id: mixerFXOn; path: app_prefix + "fx.on" }
+  AppProperty { id: mixerFX; path: app_prefix + "fx.select" }
 
-  WiresGroup
+WiresGroup
   {
-    enabled: !channel.shift || (fxMode.value == FxMode.TwoFxUnits)
+    enabled: (!channel.shift || (fxMode.value == FxMode.TwoFxUnits)) && !prefs.mixerFXSelector && !prefs.prioritizeFXSelection
     Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
     Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
   }
 
   WiresGroup
   {
-    enabled: channel.shift && (fxMode.value == FxMode.FourFxUnits)
+    enabled: (!channel.shift) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (!channel.shift) && prefs.mixerFXSelector && prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 4) % 5; } } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 1) % 5; } } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (fxMode.value == FxMode.FourFxUnits)) && !prefs.mixerFXSelector && !prefs.prioritizeFXSelection
     Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.3"; } }
     Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.4"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (!mixerFXOn.value && fxMode.value == FxMode.FourFxUnits)) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.3"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.4"; } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift && (mixerFXOn.value || fxMode.value == FxMode.TwoFxUnits)) && prefs.mixerFXSelector && !prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 4) % 5; } } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: ButtonScriptAdapter { onRelease: { mixerFX.value = (mixerFX.value + 1) % 5; } } }
+  }
+
+  WiresGroup
+  {
+    enabled: (channel.shift) && prefs.mixerFXSelector && prefs.prioritizeFXSelection
+    Wire { from: surface_prefix + "fx.assign.1"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.1"; } }
+    Wire { from: surface_prefix + "fx.assign.2"; to: TogglePropertyAdapter { path: app_prefix + "fx.assign.2"; } }
+  }
+
+  Prefs{
+    id:prefs
   }
 
 }

--- a/Screens/Defines/Prefs.qml
+++ b/Screens/Defines/Prefs.qml
@@ -2,6 +2,10 @@ import QtQuick 2.0
 
 QtObject {
 
+    // controller preferences
+    readonly property bool mixerFXSelector:			false
+	readonly property bool prioritizeFXSelection:	true
+
 	// global preferences
 	readonly property bool camelotKey: 				true
 	readonly property int  phraseLength:            4


### PR DESCRIPTION
Added the ability to change MixerFX by using the FX Unit assignment buttons (the little arrows at the top of each channel). Pressing SHIFT+Arrows will assign FX units 1 and 2 to the respective channel. If prioritizeFXSelection is set to false then by default the arrow buttons will assign FX units 1 and 2, pressing SHIFT+Arrows change the MixerFX but only if the filter is on, otherwisw it will assign FX units 3 and 4.